### PR TITLE
Reference SNSTransportService using the correct case in Transporter::sendOverAwsSns()

### DIFF
--- a/src/Services/Transporter.php
+++ b/src/Services/Transporter.php
@@ -47,7 +47,7 @@ class Transporter
     {
         try {
             if (intval(config('otp.send-by.aws-sns')) === 1 && !empty($request->number)) {
-                self::sendOver(new SnsTransportService($request->number, $otp));
+                self::sendOver(new SNSTransportService($request->number, $otp));
             }
         } catch (\Exception $ex) {
             return false;


### PR DESCRIPTION
Some autoloaders such as Composer's (see e.g. https://github.com/composer/composer/issues/1803) are case sensitive.
Since `Transporter::sendOverAwsSns()` references `SNSTransportService` using the wrong case (`Sns...` instead of `SNS...`) this can result in the library always failing to send messages via SNS.

This change avoids this issue by using the correct case.