### PR TITLE
Set SMS type to Transactional via `MessageAttributes` when using AWS SNS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -339,7 +339,6 @@ Create a IAM user with the appropriate policy permissions. Go to the IAM service
             "Effect": "Allow",
             "Action": [
                 "sns:Publish",
-                "sns:SetSMSAttributes",
                 "sns:CheckIfPhoneNumberIsOptedOut"
             ],
             "Resource": [
@@ -350,4 +349,4 @@ Create a IAM user with the appropriate policy permissions. Go to the IAM service
 }
 ```
 
-Here we set the ability to publish, set SMS attributes and check for opt-outs and apply this across a wildcard resource instead of a specific topic as we will be sending notifications directly to phone numbers and not an SNS topic.
+Here we set the ability to publish, check for opt-outs, and apply this across a wildcard resource instead of a specific topic as we will be sending notifications directly to phone numbers and not an SNS topic.

--- a/src/Services/SNSTransportService.php
+++ b/src/Services/SNSTransportService.php
@@ -45,13 +45,6 @@ class SNSTransportService implements TransportServiceInterface
                 ),
                 'region' => config('otp.aws.sns.region'),
             ]);
-
-            // For SMS Sending Reliability
-            $this->client->SetSMSAttributes([
-                'attributes' => [
-                    'DefaultSMSType' => 'Transactional',
-                ],
-            ]);
         }
 
         $this->number = $number;
@@ -103,6 +96,13 @@ class SNSTransportService implements TransportServiceInterface
 
             $result = $this->client->publish([
                 'Message' => $message,
+                'MessageAttributes' => [
+                    // For SMS Sending Reliability
+                    'AWS.SNS.SMS.SMSType' => [
+                        'DataType' => 'String',
+                        'StringValue' => 'Transactional',
+                    ],
+                ],
                 'PhoneNumber' => $number,
             ]);
 


### PR DESCRIPTION
... instead of using a `SetSMSAttributes` request.

While globally setting the default SMS type via `SetSMSAttributes` does work most of the time, it has some issues:
1. It requires an extra IAM permission.
2. It forces users of the library to use transactional SMSes as the default. This may not be what they want.
3. Per https://docs.aws.amazon.com/general/latest/gr/sns.html#limits_sns_api_throttles_hard `SetSMSAttributes` is rate limited to one transaction per second. Rates for sending SMSes via SNS are generally multiple messages per second, so using `SetSMSAttributes` makes the library less suitable for supporting many users at the same time.
4. In theory there's a race condition where this library sets the global value to transactional, some other code somewhere sets the global value to promotional immediately after, resulting in an OTP message being sent as promotional.

This commit instead switches to specifying the message type using the `AWS.SNS.SMS.SMSType` attribute.
This avoids all of the issues above while still ensuring OTP messages are sent as transactional.

See https://docs.aws.amazon.com/sns/latest/dg/sms_publish-to-phone.html#sms_publish_sdk for details.