### PR TITLE
Allow custom mailable class to be specified for e-mail OTPs

### DIFF
--- a/config/otp.php
+++ b/config/otp.php
@@ -17,6 +17,11 @@ return [
     ],
     'email' => [
         'from' => env('OTP_EMAIL_FROM','example@mail.com'),
+        // Class string specifying the `Mailable` class to use when sending e-mail OTPs.
+        // The constructor of the class will be called with a single string argument (the OTP
+        // value).
+        // If this config is left unspecified a default mailable class will be used.
+        'mailable-class' => Ferdous\OtpValidator\Services\OtpMailable::class,
         'name' => env('OTP_EMAIL_FROM_NAME','Example'),
         'subject' => env('OTP_EMAIL_SUBJECT','Security Code')
     ],

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,9 @@ This command will create a `config/otp.php` file.
 ### Email Configs
 From the `.env` file the email configs are setup. No other changes required.
 
+See the `otp.php` file for optional customizations such as the ability to specify a custom
+`Mailable` class.
+
 ### SMS Configs
 As the SMS Gateways use different methods and also extra headers and params, you may need to update the sms configs in the `otp.php` file.
 

--- a/src/Services/EmailTransportService.php
+++ b/src/Services/EmailTransportService.php
@@ -17,8 +17,9 @@ class EmailTransportService implements TransportServiceInterface
 
     public function send()
     {
+        $mailableClass = config('otp.email.mailable-class', OtpMailable::class);
         if (!empty($this->email) && !empty($this->otp)) {
-            Mail::to($this->email)->send(new OtpMailable($this->otp));
+            Mail::to($this->email)->send(new $mailableClass($this->otp));
         }
     }
 


### PR DESCRIPTION
Fixes ferdousulhaque/laravel-otp-validate#6.

Users of the library that don't explicitly specify a custom class will continue to use the existing `OtpMailable` class, either through the default value in `config/otp.php` or via the default value specified in `EmailTransportService`.